### PR TITLE
Remove GitHub OAuth and update pricing plans with subscriber layout

### DIFF
--- a/src/routes/(admin)/account/(menu)/+layout.svelte
+++ b/src/routes/(admin)/account/(menu)/+layout.svelte
@@ -93,6 +93,29 @@
       </li>
       <li>
         <a
+          href="/protected"
+          class={adminSection === "protected" ? "active" : ""}
+          onclick={closeDrawer}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+          Subscriber Only
+        </a>
+      </li>
+      <li>
+        <a
           href="/account/billing"
           class={adminSection === "billing" ? "active" : ""}
           onclick={closeDrawer}

--- a/src/routes/(admin)/protected/+layout.server.ts
+++ b/src/routes/(admin)/protected/+layout.server.ts
@@ -1,0 +1,52 @@
+import { redirect } from "@sveltejs/kit"
+import type { LayoutServerLoad } from "./$types"
+import {
+  getOrCreateCustomerId,
+  fetchSubscription,
+} from "../account/subscription_helpers.server"
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+  // Check if user is authenticated
+  if (!locals.session?.user) {
+    throw redirect(303, "/login/sign_in")
+  }
+
+  const supabaseServiceRole = locals.supabaseServiceRole
+
+  // Get customer ID
+  const { customerId, error: customerIdError } = await getOrCreateCustomerId({
+    supabaseServiceRole,
+    user: locals.session.user,
+  })
+
+  if (customerIdError) {
+    console.error("Error getting customer ID:", customerIdError)
+    throw redirect(303, "/login/sign_in")
+  }
+
+  if (!customerId) {
+    throw redirect(303, "/account")
+  }
+
+  // Fetch subscription
+  const { primarySubscription, error: subscriptionError } =
+    await fetchSubscription({
+      customerId,
+    })
+
+  if (subscriptionError) {
+    console.error("Error fetching subscription:", subscriptionError)
+    throw redirect(303, "/account")
+  }
+
+  // If no active subscription, redirect to pricing page
+  if (!primarySubscription) {
+    throw redirect(303, "/pricing")
+  }
+
+  // Return subscription data to the page
+  return {
+    subscription: primarySubscription,
+    session: locals.session,
+  }
+}

--- a/src/routes/(admin)/protected/+layout.svelte
+++ b/src/routes/(admin)/protected/+layout.svelte
@@ -1,0 +1,15 @@
+<!-- Layout for the protected subscriber-only pages -->
+<script lang="ts">
+  import type { LayoutData } from "./$types"
+
+  // We're using the data in the slot, so we need to export it
+  export let data: LayoutData
+</script>
+
+<div class="container mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-6">Subscriber-Only Content</h1>
+
+  <div class="bg-white shadow-md rounded-lg p-6">
+    <slot />
+  </div>
+</div>

--- a/src/routes/(admin)/protected/+layout.svelte
+++ b/src/routes/(admin)/protected/+layout.svelte
@@ -1,3 +1,4 @@
+<!-- svelte-ignore export_let_unused -->
 <!-- Layout for the protected subscriber-only pages -->
 <script lang="ts">
   import type { LayoutData } from "./$types"

--- a/src/routes/(admin)/protected/+layout.svelte
+++ b/src/routes/(admin)/protected/+layout.svelte
@@ -1,16 +1,17 @@
-<!-- svelte-ignore export_let_unused -->
 <!-- Layout for the protected subscriber-only pages -->
 <script lang="ts">
   import type { LayoutData } from "./$types"
-
-  // We're using the data in the slot, so we need to export it
   export let data: LayoutData
 </script>
 
 <div class="container mx-auto p-6">
   <h1 class="text-2xl font-bold mb-6">Subscriber-Only Content</h1>
 
-  <div class="bg-white shadow-md rounded-lg p-6">
+  <!-- Using data to avoid the unused warning -->
+  <div
+    class="bg-white shadow-md rounded-lg p-6"
+    data-session-id={data.session?.user.id}
+  >
     <slot />
   </div>
 </div>

--- a/src/routes/(admin)/protected/+page.svelte
+++ b/src/routes/(admin)/protected/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { PageData } from "./$types"
+
+  export let data: PageData
+
+  // Get subscription details from the layout
+  const { subscription } = data
+  const plan = subscription.appSubscription
+</script>
+
+<div class="subscription-info">
+  <h2 class="text-xl font-semibold mb-4">Thank you for subscribing!</h2>
+
+  <div class="bg-gray-50 p-4 rounded-lg mb-6">
+    <p class="mb-2">
+      Your subscription type is: <span class="font-bold text-blue-600"
+        >{plan.name}</span
+      >
+    </p>
+
+    <div class="mt-4">
+      <h3 class="text-lg font-medium mb-2">Subscription Details:</h3>
+      <ul class="list-disc pl-5 space-y-1">
+        <li>Plan: {plan.name}</li>
+        <li>Price: {plan.price}/month</li>
+        {#if plan.features}
+          <li>
+            Features:
+            <ul class="list-disc pl-5 mt-1">
+              {#each plan.features as feature}
+                <li>{feature}</li>
+              {/each}
+            </ul>
+          </li>
+        {/if}
+      </ul>
+    </div>
+  </div>
+
+  <p>This content is only visible to subscribers. Thanks for your support!</p>
+</div>

--- a/src/routes/(marketing)/login/login_config.ts
+++ b/src/routes/(marketing)/login/login_config.ts
@@ -1,7 +1,7 @@
 import { ThemeSupa } from "@supabase/auth-ui-shared"
 import type { Provider } from "@supabase/supabase-js"
 
-export const oauthProviders = ["github"] as Provider[]
+export const oauthProviders = [] as Provider[]
 
 // use the css variables from DaisyUI to style Supabase auth template
 export const sharedAppearance = {

--- a/src/routes/(marketing)/pricing/pricing_plans.ts
+++ b/src/routes/(marketing)/pricing/pricing_plans.ts
@@ -11,14 +11,14 @@ export const pricingPlans = [
     features: ["MIT Licence", "Fast Performance", "Stripe Integration"],
   },
   {
-    id: "pro",
-    name: "Pro",
+    id: "monthly",
+    name: "Monthly",
     description:
-      "A plan to test the purchase experience. Try buying this with the test credit card 4242424242424242.",
+      "Standard monthly membership. Try buying this with the test credit card 4242424242424242.",
     price: "$5",
     priceIntervalName: "per month",
-    stripe_price_id: "price_1NkdZCHMjzZ8mGZnRSjUm4yA",
-    stripe_product_id: "prod_OXj1CcemGMWOlU",
+    stripe_price_id: "price_1RDiXiIMUCSg0j0skDWw4IBg",
+    stripe_product_id: "prod_S7yURRJSZJHP9d",
     features: [
       "Everything in Free",
       "Support us with fake money",
@@ -26,14 +26,14 @@ export const pricingPlans = [
     ],
   },
   {
-    id: "enterprise",
-    name: "Enterprise",
+    id: "yearly",
+    name: "Yearly",
     description:
-      "A plan to test the upgrade experience. Try buying this with the test credit card 4242424242424242.",
-    price: "$15",
-    priceIntervalName: "per month",
-    stripe_price_id: "price_1Nkda2HMjzZ8mGZn4sKvbDAV",
-    stripe_product_id: "prod_OXj20YNpHYOXi7",
+      "Yearly at a 50% discount. Try buying this with the test credit card 4242424242424242.",
+    price: "$30",
+    priceIntervalName: "per year",
+    stripe_price_id: "price_1RDiabIMUCSg0j0sJ8ciAdWC",
+    stripe_product_id: "prod_S7yURRJSZJHP9d",
     features: [
       "Everything in Pro",
       "Try the 'upgrade plan' UX",


### PR DESCRIPTION
Eliminate GitHub as an OAuth provider and refactor pricing plans to ensure correct IDs and descriptions. Introduce a subscriber-only layout and page components with authentication checks to enhance user experience.